### PR TITLE
Update references to newer Firebase classes

### DIFF
--- a/FriendlyChat/FriendlyChatSwift/AppDelegate.swift
+++ b/FriendlyChat/FriendlyChatSwift/AppDelegate.swift
@@ -35,6 +35,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
     
     func application(_ application: UIApplication, open url: URL, sourceApplication: String?, annotation: Any) -> Bool {
-        return FUIAuth.defaultAuthUI()?.handleOpen(url, sourceApplication: sourceApplication ?? "") ?? false
+        return (FIRAuthUI.authUI()?.handleOpen(url, sourceApplication: sourceApplication ?? "")) ?? false
     }
 }

--- a/FriendlyChat/FriendlyChatSwift/FCViewController.swift
+++ b/FriendlyChat/FriendlyChatSwift/FCViewController.swift
@@ -162,7 +162,7 @@ class FCViewController: UIViewController, UINavigationControllerDelegate {
     
     @IBAction func signOut(_ sender: UIButton) {
         do {
-            try FIRAuth.auth()?.signOut()
+            try FIRAuth.auth().signOut()
         } catch {
             print("unable to sign out: \(error)")
         }

--- a/FriendlyChat/FriendlyChatSwift/FCViewController.swift
+++ b/FriendlyChat/FriendlyChatSwift/FCViewController.swift
@@ -24,17 +24,17 @@ class FCViewController: UIViewController, UINavigationControllerDelegate {
     
     // MARK: Properties
     
-    var ref: DatabaseReference!
-    var messages: [DataSnapshot]! = []
+    var ref: FIRDatabaseReference!
+    var messages: [FIRDataSnapshot]! = []
     var msglength: NSNumber = 1000
-    var storageRef: StorageReference!
-    var remoteConfig: RemoteConfig!
+    var storageRef: FIRStorageReference!
+    var remoteConfig: FIRRemoteConfig!
     let imageCache = NSCache<NSString, UIImage>()
     var keyboardOnScreen = false
     var placeholderImage = UIImage(named: "ic_account_circle")
-    fileprivate var _refHandle: DatabaseHandle!
-    fileprivate var _authHandle: AuthStateDidChangeListenerHandle!
-    var user: User?
+    fileprivate var _refHandle: FIRDatabaseHandle!
+    fileprivate var _authHandle: FIRAuthStateDidChangeListenerHandle!
+    var user: FIRUser?
     var displayName = "Anonymous"
     
     // MARK: Outlets
@@ -114,7 +114,7 @@ class FCViewController: UIViewController, UINavigationControllerDelegate {
     }
     
     func loginSession() {
-        let authViewController = FUIAuth.defaultAuthUI()!.authViewController()
+        let authViewController = FIRAuthUI.authUI()!.authViewController()
         self.present(authViewController, animated: true, completion: nil)
     }
     
@@ -162,7 +162,7 @@ class FCViewController: UIViewController, UINavigationControllerDelegate {
     
     @IBAction func signOut(_ sender: UIButton) {
         do {
-            try Auth.auth().signOut()
+            try FIRAuth.auth()?.signOut()
         } catch {
             print("unable to sign out: \(error)")
         }


### PR DESCRIPTION
- The project is now longer building due to it not being able to references the classes after a `pod isntall`.
- Update Firebase references to newer names.

For someone at Udacity: Update the zipped version at: https://classroom.udacity.com/courses/ud0351/lessons/fce29016-a52a-4740-95fe-ccf0ab16710c/concepts/3bb46789-2b0f-4e88-8c4b-95d2b3357017